### PR TITLE
Fixing proxy's stored function name in example code

### DIFF
--- a/Recipes/Protocols.md
+++ b/Recipes/Protocols.md
@@ -190,7 +190,7 @@ final class URLSessionDelegateProxy: NSObject {
 
 extension URLSessionDelegateProxy: URLSessionDelegate {
     func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
-        finishHandler()
+        eventsFinished()
     }
 }
 


### PR DESCRIPTION
I assume the stored handler function was renamed from finishHandler to eventsFinished?