### PR TITLE
Fix protocols path when viewing on GitHub.

### DIFF
--- a/Recipes/SwiftUI.md
+++ b/Recipes/SwiftUI.md
@@ -41,4 +41,4 @@ struct MyView: View {
 
 ## EnvironmentKey/PreferencesKey
 
-These can be hard to use! Check out the [protocol section](Recipes/Protocols.md) for ideas.
+These can be hard to use! Check out the [protocol section](Protocols.md) for ideas.

--- a/Recipes/SwiftUI.md
+++ b/Recipes/SwiftUI.md
@@ -41,4 +41,4 @@ struct MyView: View {
 
 ## EnvironmentKey/PreferencesKey
 
-These can be hard to use! Check out the [protocol section](Protocols.md) for ideas.
+These can be hard to use! Check out the [protocol section](./Protocols.md) for ideas.


### PR DESCRIPTION
## ℹ️ 

When viewing on GitHub, tapping on `protocol section` link adds extra `Recipes/` to the path, resulting in a 404.

## 🖼️ 

<img width="1105" alt="Screenshot 2025-02-01 at 21 16 19" src="https://github.com/user-attachments/assets/99ce5dcc-495e-4efc-97a3-f542cca6ac45" />

